### PR TITLE
Calling EOS.undent is Now Disabled

### DIFF
--- a/Formula/bats-file.rb
+++ b/Formula/bats-file.rb
@@ -15,7 +15,7 @@ class BatsFile < Formula
   end
 
   def caveats
-    <<-EOS.undent
+    <<~EOS
 
     To load the bats-file lib in your bats test:
 


### PR DESCRIPTION
And replaced by the Ruby squiggly HEREDOC syntax