### PR TITLE
Calling EOS.undent is Now Disabled

### DIFF
--- a/Formula/bats-assert.rb
+++ b/Formula/bats-assert.rb
@@ -15,7 +15,7 @@ class BatsAssert < Formula
   end
 
   def caveats
-    <<-EOS.undent
+    <<~EOS
 
     To load the bats-assert lib in your bats test:
 


### PR DESCRIPTION
And replaced by the Ruby squiggly HEREDOC syntax