### PR TITLE
Calling EOS.undent is Now Disabled

### DIFF
--- a/Formula/bats-mock.rb
+++ b/Formula/bats-mock.rb
@@ -14,7 +14,7 @@ class BatsMock < Formula
   end
 
   def caveats
-    <<-EOS.undent
+    <<~EOS
 
     To load the bats-mock lib in your bats test:
 


### PR DESCRIPTION
And replaced by the Ruby squiggly HEREDOC syntax