### PR TITLE
The `undent` method is no longer supported [re: Issue #4]

### DIFF
--- a/Formula/bats-mock.rb
+++ b/Formula/bats-mock.rb
@@ -14,7 +14,7 @@ class BatsMock < Formula
   end
 
   def caveats
-    <<-EOS.undent
+    <<~EOS
 
     To load the bats-mock lib in your bats test:
 
@@ -24,7 +24,7 @@ class BatsMock < Formula
   end
 
   test do
-    tests = <<-EOS.undent
+    tests = <<~EOS
       load '#{HOMEBREW_PREFIX}/lib/bats-mock/stub.bash'
       @test "uname -s" {
         stub uname '-s : echo Stubbed'

--- a/Formula/bats-mock.rb
+++ b/Formula/bats-mock.rb
@@ -16,7 +16,7 @@ class BatsMock < Formula
   def caveats
     <<~EOS
 
-    To load the bats-mock lib in your bats test:
+      To load the bats-mock lib in your bats test:
 
         load '#{HOMEBREW_PREFIX}/lib/bats-mock/stub.bash'
 


### PR DESCRIPTION
[Issue #4]: https://github.com/kaos/homebrew-shell/issues/4